### PR TITLE
Fix version conflicts caused by PR#232

### DIFF
--- a/src/Common.props
+++ b/src/Common.props
@@ -31,9 +31,9 @@
         <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8" />
 
         <!-- Fixes CS8034: Unable to load Analyzer assembly [...] Microsoft.AspNetCore.Components.Analyzers.dll : Assembly with same name is already loaded -->
-        <PackageReference Include="Microsoft.AspNetCore.Components.Analyzers" Version="3.1.3" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.Analyzers" Version="5.0.0" />
 
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.3" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
     </ItemGroup>
 
     <!-- Git versioning -->

--- a/src/Return.Domain/Return.Domain.csproj
+++ b/src/Return.Domain/Return.Domain.csproj
@@ -14,6 +14,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Return.Persistence/Return.Persistence.csproj
+++ b/src/Return.Persistence/Return.Persistence.csproj
@@ -9,21 +9,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.3">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.8" />
 
     <!-- Health checks for Docker -->
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="3.1.3"/>
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="5.0.8"/>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Return.Application.Tests.Unit/Return.Application.Tests.Unit.csproj
+++ b/tests/Return.Application.Tests.Unit/Return.Application.Tests.Unit.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.0" />
     <PackageReference Include="NSubstitute " Version="4.2.1" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp " Version="1.0.12" />
   </ItemGroup>


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump Microsoft.EntityFrameworkCore.Sqlite from 3.1.3 to 5.0.8 in /src/Return.Web. [(PR#232)](https://github.com/Sebazzz/Return/pull/232).
Hope this fix can help you.

Best regards,
sucrose